### PR TITLE
feat: add GitHub stars count and open-source indicator #12

### DIFF
--- a/cur8t-web/src/app/page.tsx
+++ b/cur8t-web/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { SignInButton, SignUpButton, useAuth } from '@clerk/nextjs';
 import Link from 'next/link';
 import Hero from '@/components/landingPage/Hero';
@@ -44,10 +44,14 @@ import { PiCode, PiHeart, PiChatCircle } from 'react-icons/pi';
 import Faq1 from '@/components/landingPage/faq';
 import Footer from '@/components/layout/Footer';
 import { Button } from '@/components/ui/button';
+import { FaGithub } from 'react-icons/fa';
+import { Star } from 'lucide-react';
+import { AnimatedNumber } from '@/components/ui/animated-number';
 
 const Home = () => {
   const [isOpen, setIsOpen] = useState(false);
   const { isSignedIn } = useAuth();
+  const [githubStars, setGithubStars] = useState(0);
 
   const navItems = [
     { name: 'Home', link: '#home' },
@@ -66,6 +70,29 @@ const Home = () => {
       element.scrollIntoView({ behavior: 'smooth' });
     }
   };
+
+  useEffect(() => {
+    const githubStarsCount = async () => {
+      try {
+        const response = await fetch(
+          'https://api.github.com/repos/amaan8429/cur8t',
+          {
+            headers: {
+              Accept: 'application/vnd.github.v3+json',
+            },
+          }
+        );
+        if (!response.ok) {
+          throw new Error('Failed to fetch GitHub stars');
+        }
+        const data = await response.json();
+        setGithubStars(data.stargazers_count || 0);
+      } catch (error) {
+        throw new Error('Failed to fetch GitHub stars');
+      }
+    };
+    githubStarsCount();
+  }, []);
 
   return (
     <div
@@ -89,14 +116,39 @@ const Home = () => {
                 </NavbarButton>
               </Link>
             ) : (
-              <SignUpButton
-                mode="modal"
-                forceRedirectUrl="/dashboard?item=Overview"
-              >
-                <NavbarButton variant="primary" as="button">
-                  Get Started
-                </NavbarButton>
-              </SignUpButton>
+              <>
+                <Link
+                  href={'https://github.com/amaan8429/cur8t'}
+                  target="_blank"
+                  className="cursor-pointer group"
+                >
+                  <NavbarButton
+                    variant="secondary"
+                    as="button"
+                    className="flex items-center gap-2"
+                  >
+                    <div className="flex items-center gap-1">
+                      <FaGithub className="size-4 mb-[2px]" />
+                      <span>Github</span>
+                    </div>
+                    <div className="flex items-center gap-1 text-sm">
+                      <Star className="size-4 mb-[2px] fill-gray-400 duration-300 group-hover:fill-yellow-400 group-hover:stroke-yellow-400 group-hover:drop-shadow-[0_0_8px_rgba(250,204,21,0.6)]" />
+                      <AnimatedNumber
+                        value={githubStars}
+                        className="font-medium text-white"
+                      />
+                    </div>
+                  </NavbarButton>
+                </Link>
+                <SignUpButton
+                  mode="modal"
+                  forceRedirectUrl="/dashboard?item=Overview"
+                >
+                  <NavbarButton variant="primary" as="button">
+                    Get Started
+                  </NavbarButton>
+                </SignUpButton>
+              </>
             )}
           </div>
         </NavBody>

--- a/cur8t-web/src/app/page.tsx
+++ b/cur8t-web/src/app/page.tsx
@@ -88,7 +88,8 @@ const Home = () => {
         const data = await response.json();
         setGithubStars(data.stargazers_count || 0);
       } catch (error) {
-        throw new Error('Failed to fetch GitHub stars');
+        console.error('Failed to fetch GitHub stars', error);
+        setGithubStars(0);
       }
     };
     githubStarsCount();

--- a/cur8t-web/src/components/landingPage/Hero.tsx
+++ b/cur8t-web/src/components/landingPage/Hero.tsx
@@ -461,7 +461,7 @@ export default function Hero({ isSignedIn }: { isSignedIn: boolean }) {
           <span className="mr-2 rounded-full bg-primary px-2 py-0.5 text-xs font-semibold text-primary-foreground">
             New
           </span>
-          Backed by Sydney Sweeney
+         Proudly Open Source
         </motion.div>
 
         {/* Main Heading */}

--- a/cur8t-web/src/components/landingPage/Hero.tsx
+++ b/cur8t-web/src/components/landingPage/Hero.tsx
@@ -461,7 +461,7 @@ export default function Hero({ isSignedIn }: { isSignedIn: boolean }) {
           <span className="mr-2 rounded-full bg-primary px-2 py-0.5 text-xs font-semibold text-primary-foreground">
             New
           </span>
-         Proudly Open Source
+          Proudly Open Source
         </motion.div>
 
         {/* Main Heading */}

--- a/cur8t-web/src/components/ui/animated-number.tsx
+++ b/cur8t-web/src/components/ui/animated-number.tsx
@@ -1,0 +1,28 @@
+import { motion, type SpringOptions, useSpring, useTransform } from 'motion/react';
+import { useEffect } from 'react';
+import { cn } from '@/lib/utils';
+
+export type AnimatedNumberProps = {
+  value: number;
+  className?: string;
+  springOptions?: SpringOptions;
+  as?: React.ElementType;
+};
+
+export function AnimatedNumber({
+  value,
+  className,
+  springOptions,
+  as = 'span',
+}: AnimatedNumberProps) {
+  const MotionComponent = motion.create(as);
+
+  const spring = useSpring(value, springOptions);
+  const display = useTransform(spring, (current) => Math.round(current).toLocaleString());
+
+  useEffect(() => {
+    spring.set(value);
+  }, [spring, value]);
+
+  return <MotionComponent className={cn('tabular-nums', className)}>{display}</MotionComponent>;
+}

--- a/cur8t-web/src/components/ui/animated-number.tsx
+++ b/cur8t-web/src/components/ui/animated-number.tsx
@@ -1,4 +1,9 @@
-import { motion, type SpringOptions, useSpring, useTransform } from 'motion/react';
+import {
+  motion,
+  type SpringOptions,
+  useSpring,
+  useTransform,
+} from 'motion/react';
 import { useEffect } from 'react';
 import { cn } from '@/lib/utils';
 
@@ -18,11 +23,17 @@ export function AnimatedNumber({
   const MotionComponent = motion.create(as);
 
   const spring = useSpring(value, springOptions);
-  const display = useTransform(spring, (current) => Math.round(current).toLocaleString());
+  const display = useTransform(spring, (current) =>
+    Math.round(current).toLocaleString()
+  );
 
   useEffect(() => {
     spring.set(value);
   }, [spring, value]);
 
-  return <MotionComponent className={cn('tabular-nums', className)}>{display}</MotionComponent>;
+  return (
+    <MotionComponent className={cn('tabular-nums', className)}>
+      {display}
+    </MotionComponent>
+  );
 }


### PR DESCRIPTION
### Title 
Add GitHub stars count and open source indicator on the landing page.

### How Has This Been Tested?

- [x] Displaying the number of GitHub stars for the repository.
- [x] Adding an Open Source indicator to clearly show that this project is open source.

### Checklist:

- [x] Code follows the project’s style guidelines
- [x] Changes tested locally
- [x] PR description is clear and concise

This PR closes/fixes #12 and enhances the landing page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a GitHub link button on the landing page for signed-out users that shows the repository and a live star count with an animated number.
  - Introduced an animated number component to smoothly render changing numeric values.

- Style
  - Updated the Hero badge text to “Proudly Open Source.”

- UX
  - Preserved the existing “Get Started” sign-up flow; the Get Started button remains and now appears alongside the new GitHub button for unauthenticated visitors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->