### PR TITLE
Enhancement: Replace Sign In button with Chrome Extension CTA in hero section / redundant buttons in hero section

### DIFF
--- a/cur8t-web/src/components/landingPage/Hero.tsx
+++ b/cur8t-web/src/components/landingPage/Hero.tsx
@@ -620,18 +620,20 @@ export default function Hero({ isSignedIn }: { isSignedIn: boolean }) {
                 </Button>
               </SignUpButton>
 
-              <SignInButton
-                mode="modal"
-                forceRedirectUrl="/dashboard?item=Overview"
+              <Link
+                href="https://chromewebstore.google.com/detail/cur8t/nmimopllfhdfejjajepepllgdpkglnnj?utm_source=item-share-cb"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <Button
                   variant="outline"
                   className="border-2 border-border hover:border-primary bg-background/50 backdrop-blur-sm text-foreground hover:text-primary hover:bg-primary/5 px-8 py-6 text-base font-medium transition-all duration-300 hover:-translate-y-0.5"
                   size="lg"
                 >
-                  Sign In
+                  Chrome Extension
+                  <PiArrowUpRight className="ml-2 h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
                 </Button>
-              </SignInButton>
+              </Link>
             </>
           )}
         </motion.div>


### PR DESCRIPTION
Fix: #22
Updated the hero section CTA buttons for non-signed-in users to better promote the Chrome Extension. The second CTA button was previously directing users to sign in, but now redirects to our Chrome Web Store listing to increase extension installations.

Changes Made
Replaced <SignInButton> component with Next.js <Link> component
Updated button text from "Sign In" to "Chrome Extension"

Added external link to Chrome Web Store: https://chromewebstore.google.com/detail/cur8t/nmimopllfhdfejjajepepllgdpkglnnj?utm_source=item-share-cb
Added security attributes (target="_blank", rel="noopener noreferrer") for safe external linking
Changed button icon from none to PiArrowUpRight to indicate external link behavior
Maintained all existing styling and hover effects for design consistency


Technical Details
File Modified: src/components/Hero.tsx (or your hero component path)

Before:
Both CTA buttons directed to sign-in/sign-up flows

After:
Primary CTA: "Get Started" → Sign up modal
Secondary CTA: "Chrome Extension" → Chrome Web Store (new tab)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the not-signed-in call-to-action to open the Chrome Web Store in a new tab, replacing the previous in-app sign-in modal flow.
  * Button label now reads “Chrome Extension” and includes an outward arrow icon to indicate external navigation.
  * Removes the previous dashboard redirect on sign-in, streamlining access to the extension.
  * Sign-up option remains available and unchanged.
