### PR TITLE
feat: add new API routes for VS Code extension

### DIFF
--- a/extension-api/app/api/vscode_routes.py
+++ b/extension-api/app/api/vscode_routes.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 from fastapi import APIRouter, Header, HTTPException, Request
 from pydantic import BaseModel, validator
 
-from ..core.database import execute_insert, execute_query_one, execute_query_all
+from ..core.database import execute_insert, execute_query_all, execute_query_one
 from ..core.subscription import subscription_service
 from ..core.utils import limiter
 from ..models.schemas import Collection, CreateCollectionResponse, ErrorResponse
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+
 # VS Code Extension specific schemas
 class VSCodeExtension(BaseModel):
     id: str
@@ -28,20 +29,24 @@ class VSCodeExtension(BaseModel):
     name: str
     publisher: str
 
+
 class ExportCollectionRequest(BaseModel):
     extensions: List[Dict[str, str]]
     collectionName: Optional[str] = None
     description: Optional[str] = None
+
 
 class ExportCollectionResponse(BaseModel):
     collectionId: str
     collectionUrl: str
     message: str
 
+
 class ValidateResponse(BaseModel):
     userId: str
     email: Optional[str] = None
     username: Optional[str] = None
+
 
 @router.get("/validate", response_model=ValidateResponse)
 @limiter.limit("60/minute")
@@ -52,7 +57,7 @@ async def validate_api_key(
     logger.info(f"[DEBUG] /validate called with header: {authorization}")
 
     """Validate API key and return basic user info"""
-    
+
     try:
         user_id = await get_user_id_from_api_key(authorization)
         logger.info(f"[DEBUG] got user_id: {user_id}")
@@ -73,7 +78,7 @@ async def validate_api_key(
         )
     except HTTPException as e:
         logger.error(f"[HTTPException] {e.detail}")
-        raise e         # Re-raise the real status and message
+        raise e  # Re-raise the real status and message
     except Exception as e:
         logger.error(f"[EXCEPTION] {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -93,7 +98,9 @@ async def export_vscode_extensions(
         raise HTTPException(status_code=400, detail="Too many extensions (max: 1000)")
     """Export VS Code extensions to a Cur8t collection"""
     logger.info("🚀 VS CODE EXPORT - Endpoint called")
-    logger.info(f"🚀 VS CODE EXPORT - Number of extensions: {len(export_data.extensions)}")
+    logger.info(
+        f"🚀 VS CODE EXPORT - Number of extensions: {len(export_data.extensions)}"
+    )
 
     try:
         user_id = await get_user_id_from_api_key(authorization)
@@ -114,8 +121,14 @@ async def export_vscode_extensions(
             )
 
         # Create collection name and description
-        collection_name = export_data.collectionName or f"VS Code Extensions - {datetime.now().strftime('%Y-%m-%d')}"
-        collection_description = export_data.description or f"Exported {len(export_data.extensions)} VS Code extensions on {datetime.now().strftime('%Y-%m-%d')}"
+        collection_name = (
+            export_data.collectionName
+            or f"VS Code Extensions - {datetime.now().strftime('%Y-%m-%d')}"
+        )
+        collection_description = (
+            export_data.description
+            or f"Exported {len(export_data.extensions)} VS Code extensions on {datetime.now().strftime('%Y-%m-%d')}"
+        )
 
         # Create new collection
         collection_id = str(uuid.uuid4())
@@ -127,8 +140,10 @@ async def export_vscode_extensions(
 
         now = datetime.utcnow()
         # Base URL from configuration or environment variable
-        collection_url = os.getenv("VSCODE_MARKETPLACE_URL", "https://marketplace.visualstudio.com")
-        
+        collection_url = os.getenv(
+            "VSCODE_MARKETPLACE_URL", "https://marketplace.visualstudio.com"
+        )
+
         created_collection = await execute_insert(
             insert_collection_query,
             (
@@ -153,7 +168,7 @@ async def export_vscode_extensions(
             try:
                 # Create marketplace URL for the extension
                 marketplace_url = f"https://marketplace.visualstudio.com/items?itemName={extension['id']}"
-                
+
                 # Create link for the extension
                 link_id = str(uuid.uuid4())
                 insert_link_query = """
@@ -164,7 +179,7 @@ async def export_vscode_extensions(
 
                 # Create a descriptive title for the extension
                 link_title = f"{extension['name']} v{extension['version']}"
-                if extension.get('description'):
+                if extension.get("description"):
                     link_title += f" - {extension['description'][:100]}"
 
                 created_link = await execute_insert(
@@ -184,7 +199,9 @@ async def export_vscode_extensions(
                     created_links.append(created_link)
 
             except Exception as e:
-                logger.error(f"❌ Failed to create link for extension {extension['id']}: {str(e)}")
+                logger.error(
+                    f"❌ Failed to create link for extension {extension['id']}: {str(e)}"
+                )
                 continue
 
         # Update collection's total links count
@@ -202,12 +219,14 @@ async def export_vscode_extensions(
         url = os.getenv("CUR8T_WEB_URL") or "https://www.cur8t.com"
         collection_view_url = f"{url}/collection/{collection_id}"
 
-        logger.info(f"🚀 VS CODE EXPORT - Successfully created collection with {len(created_links)} extension links")
+        logger.info(
+            f"🚀 VS CODE EXPORT - Successfully created collection with {len(created_links)} extension links"
+        )
 
         return ExportCollectionResponse(
             collectionId=collection_id,
             collectionUrl=collection_view_url,
-            message=f"Successfully exported {len(created_links)} VS Code extensions to Cur8t collection"
+            message=f"Successfully exported {len(created_links)} VS Code extensions to Cur8t collection",
         )
 
     except HTTPException:
@@ -217,6 +236,7 @@ async def export_vscode_extensions(
         raise HTTPException(
             status_code=500, detail=f"Failed to export VS Code extensions: {str(e)}"
         )
+
 
 @router.get("/user/collections")
 @limiter.limit("60/minute")
@@ -239,9 +259,7 @@ async def get_user_collections(
             LIMIT 20
         """
 
-        collections_result = await execute_query_all(
-            collections_query, (user_id,)
-        )
+        collections_result = await execute_query_all(collections_query, (user_id,))
 
         collections = []
         for col_data in collections_result:
@@ -265,11 +283,11 @@ async def get_user_collections(
             status_code=500, detail=f"Failed to fetch user collections: {str(e)}"
         )
 
+
 @router.get("/collections/{collection_id}")
 @limiter.limit("60/minute")
 async def get_collection_by_id(
-    request: Request,
-    collection_id: str, authorization: Optional[str] = Header(None)
+    request: Request, collection_id: str, authorization: Optional[str] = Header(None)
 ) -> Dict[str, Any]:
     """Get specific collection details"""
     logger.info(f"📁 COLLECTION DETAILS - Endpoint called for ID: {collection_id}")

--- a/extension-api/app/api/vscode_routes.py
+++ b/extension-api/app/api/vscode_routes.py
@@ -1,0 +1,311 @@
+import logging
+import os
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
+
+from fastapi import APIRouter, Header, HTTPException, Request
+from pydantic import BaseModel, validator
+
+from ..core.database import execute_insert, execute_query_one, execute_query_all
+from ..core.subscription import subscription_service
+from ..core.utils import limiter
+from ..models.schemas import Collection, CreateCollectionResponse, ErrorResponse
+
+# Import get_user_id_from_api_key directly to avoid circular imports
+from .routes import get_user_id_from_api_key
+
+# Set up logging
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# VS Code Extension specific schemas
+class VSCodeExtension(BaseModel):
+    id: str
+    version: str
+    description: str
+    name: str
+    publisher: str
+
+class ExportCollectionRequest(BaseModel):
+    extensions: List[Dict[str, str]]
+    collectionName: Optional[str] = None
+    description: Optional[str] = None
+
+class ExportCollectionResponse(BaseModel):
+    collectionId: str
+    collectionUrl: str
+    message: str
+
+class ValidateResponse(BaseModel):
+    userId: str
+    email: Optional[str] = None
+    username: Optional[str] = None
+
+@router.get("/validate", response_model=ValidateResponse)
+@limiter.limit("60/minute")
+async def validate_api_key(
+    request: Request,
+    authorization: Optional[str] = Header(None),
+):
+    logger.info(f"[DEBUG] /validate called with header: {authorization}")
+
+    """Validate API key and return basic user info"""
+    
+    try:
+        user_id = await get_user_id_from_api_key(authorization)
+        logger.info(f"[DEBUG] got user_id: {user_id}")
+
+        # Basic user details
+        user_query = """
+            SELECT id, email, name
+            FROM users
+            WHERE id = $1
+        """
+        user = await execute_query_one(user_query, (user_id,))
+
+        logger.info(f"🤝user found: {user}")
+        return ValidateResponse(
+            userId=str(user_id),
+            email=user.get("email") if user else None,
+            username=user.get("name") if user else None,
+        )
+    except HTTPException as e:
+        logger.error(f"[HTTPException] {e.detail}")
+        raise e         # Re-raise the real status and message
+    except Exception as e:
+        logger.error(f"[EXCEPTION] {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/export-collection", response_model=ExportCollectionResponse)
+@limiter.limit("20/minute")  # Increased limit for better UX
+async def export_vscode_extensions(
+    request: Request,
+    export_data: ExportCollectionRequest,
+    authorization: Optional[str] = Header(None),
+) -> ExportCollectionResponse:
+    # Validate input data
+    if not export_data.extensions:
+        raise HTTPException(status_code=400, detail="No extensions provided")
+    if len(export_data.extensions) > 1000:  # Reasonable limit
+        raise HTTPException(status_code=400, detail="Too many extensions (max: 1000)")
+    """Export VS Code extensions to a Cur8t collection"""
+    logger.info("🚀 VS CODE EXPORT - Endpoint called")
+    logger.info(f"🚀 VS CODE EXPORT - Number of extensions: {len(export_data.extensions)}")
+
+    try:
+        user_id = await get_user_id_from_api_key(authorization)
+        logger.info(f"🚀 VS CODE EXPORT - User ID extracted: {user_id}")
+
+        # Check subscription limits for collection creation
+        can_create, error_message, plan_slug = (
+            await subscription_service.check_collection_limit(user_id)
+        )
+        if not can_create:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": error_message,
+                    "plan": plan_slug,
+                    "upgrade_required": True,
+                },
+            )
+
+        # Create collection name and description
+        collection_name = export_data.collectionName or f"VS Code Extensions - {datetime.now().strftime('%Y-%m-%d')}"
+        collection_description = export_data.description or f"Exported {len(export_data.extensions)} VS Code extensions on {datetime.now().strftime('%Y-%m-%d')}"
+
+        # Create new collection
+        collection_id = str(uuid.uuid4())
+        insert_collection_query = """
+            INSERT INTO collections (id, title, description, visibility, user_id, total_links, created_at, updated_at, url)
+            VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8, $9)
+            RETURNING id, title, description, visibility, total_links, created_at
+        """
+
+        now = datetime.utcnow()
+        # Base URL from configuration or environment variable
+        collection_url = os.getenv("VSCODE_MARKETPLACE_URL", "https://marketplace.visualstudio.com")
+        
+        created_collection = await execute_insert(
+            insert_collection_query,
+            (
+                collection_id,
+                collection_name,
+                collection_description,
+                "public",  # VS Code extensions are public by default
+                user_id,
+                len(export_data.extensions),
+                now,
+                now,
+                collection_url,
+            ),
+        )
+
+        if not created_collection:
+            raise HTTPException(status_code=500, detail="Failed to create collection")
+
+        # Create links for each extension
+        created_links = []
+        for extension in export_data.extensions:
+            try:
+                # Create marketplace URL for the extension
+                marketplace_url = f"https://marketplace.visualstudio.com/items?itemName={extension['id']}"
+                
+                # Create link for the extension
+                link_id = str(uuid.uuid4())
+                insert_link_query = """
+                    INSERT INTO links (id, title, url, link_collection_id, user_id, created_at, updated_at)
+                    VALUES ($1::uuid, $2, $3, $4::uuid, $5, $6, $7)
+                    RETURNING id, title, url, link_collection_id, user_id, created_at, updated_at
+                """
+
+                # Create a descriptive title for the extension
+                link_title = f"{extension['name']} v{extension['version']}"
+                if extension.get('description'):
+                    link_title += f" - {extension['description'][:100]}"
+
+                created_link = await execute_insert(
+                    insert_link_query,
+                    (
+                        link_id,
+                        link_title,
+                        marketplace_url,
+                        collection_id,
+                        user_id,
+                        now,
+                        now,
+                    ),
+                )
+
+                if created_link:
+                    created_links.append(created_link)
+
+            except Exception as e:
+                logger.error(f"❌ Failed to create link for extension {extension['id']}: {str(e)}")
+                continue
+
+        # Update collection's total links count
+        update_collection_query = """
+            UPDATE collections 
+            SET total_links = $1 
+            WHERE id = $2::uuid AND user_id = $3
+        """
+        await execute_query_one(
+            update_collection_query,
+            (len(created_links), collection_id, user_id),
+        )
+
+        # Create collection URL for the response
+        url = os.getenv("CUR8T_WEB_URL") or "https://www.cur8t.com"
+        collection_view_url = f"{url}/collection/{collection_id}"
+
+        logger.info(f"🚀 VS CODE EXPORT - Successfully created collection with {len(created_links)} extension links")
+
+        return ExportCollectionResponse(
+            collectionId=collection_id,
+            collectionUrl=collection_view_url,
+            message=f"Successfully exported {len(created_links)} VS Code extensions to Cur8t collection"
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"❌ Unexpected error in VS Code export: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to export VS Code extensions: {str(e)}"
+        )
+
+@router.get("/user/collections")
+@limiter.limit("60/minute")
+async def get_user_collections(
+    request: Request, authorization: Optional[str] = Header(None)
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Get user's collections for VS Code extension"""
+    logger.info("📁 USER COLLECTIONS - Endpoint called")
+
+    try:
+        user_id = await get_user_id_from_api_key(authorization)
+        logger.info(f"📁 USER COLLECTIONS - User ID extracted: {user_id}")
+
+        # Get user's collections
+        collections_query = """
+            SELECT id, title, description, visibility, total_links as "totalLinks", created_at as "createdAt"
+            FROM collections 
+            WHERE user_id = $1
+            ORDER BY created_at DESC
+            LIMIT 20
+        """
+
+        collections_result = await execute_query_all(
+            collections_query, (user_id,)
+        )
+
+        collections = []
+        for col_data in collections_result:
+            collection = {
+                "id": str(col_data["id"]),
+                "name": col_data["title"],
+                "description": col_data["description"],
+                "createdAt": col_data["createdAt"].isoformat(),
+                "extensionCount": col_data["totalLinks"],
+            }
+            collections.append(collection)
+
+        return {"collections": collections}
+
+    except HTTPException as e:
+        logger.error(f"❌ HTTP Exception in user collections: {e.detail}")
+        raise
+    except Exception as e:
+        logger.error(f"❌ Unexpected error in user collections: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to fetch user collections: {str(e)}"
+        )
+
+@router.get("/collections/{collection_id}")
+@limiter.limit("60/minute")
+async def get_collection_by_id(
+    request: Request,
+    collection_id: str, authorization: Optional[str] = Header(None)
+) -> Dict[str, Any]:
+    """Get specific collection details"""
+    logger.info(f"📁 COLLECTION DETAILS - Endpoint called for ID: {collection_id}")
+
+    try:
+        user_id = await get_user_id_from_api_key(authorization)
+
+        # Get collection details
+        collection_query = """
+            SELECT id, title, description, visibility, total_links as "totalLinks", created_at as "createdAt"
+            FROM collections 
+            WHERE id = $1::uuid AND user_id = $2
+        """
+
+        collection_result = await execute_query_one(
+            collection_query, (collection_id, user_id)
+        )
+
+        if not collection_result:
+            raise HTTPException(status_code=404, detail="Collection not found")
+
+        collection = {
+            "id": str(collection_result["id"]),
+            "name": collection_result["title"],
+            "description": collection_result["description"],
+            "createdAt": collection_result["createdAt"].isoformat(),
+            "extensionCount": collection_result["totalLinks"],
+        }
+
+        return collection
+
+    except HTTPException as e:
+        logger.error(f"❌ HTTP Exception in collection details: {e.detail}")
+        raise
+    except Exception as e:
+        logger.error(f"❌ Unexpected error in collection details: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to fetch collection details: {str(e)}"
+        )

--- a/extension-api/app/api/vscode_routes.py
+++ b/extension-api/app/api/vscode_routes.py
@@ -141,7 +141,7 @@ async def export_vscode_extensions(
         now = datetime.utcnow()
 
         # Generate the collection view URL
-        base_url = os.getenv("CUR8T_WEB_URL") or "https://www.cur8t.com"        
+        base_url = os.getenv("CUR8T_WEB_URL") or "https://www.cur8t.com"
         collection_view_url_for_db = f"{base_url}/collection/{collection_id}"
 
         created_collection = await execute_insert(

--- a/extension-api/app/api/vscode_routes.py
+++ b/extension-api/app/api/vscode_routes.py
@@ -139,10 +139,10 @@ async def export_vscode_extensions(
         """
 
         now = datetime.utcnow()
-        # Base URL from configuration or environment variable
-        collection_url = os.getenv(
-            "VSCODE_MARKETPLACE_URL", "https://marketplace.visualstudio.com"
-        )
+
+        # Generate the collection view URL
+        base_url = os.getenv("CUR8T_WEB_URL") or "https://www.cur8t.com"        
+        collection_view_url_for_db = f"{base_url}/collection/{collection_id}"
 
         created_collection = await execute_insert(
             insert_collection_query,
@@ -155,7 +155,7 @@ async def export_vscode_extensions(
                 len(export_data.extensions),
                 now,
                 now,
-                collection_url,
+                collection_view_url_for_db,
             ),
         )
 

--- a/extension-api/app/main.py
+++ b/extension-api/app/main.py
@@ -12,8 +12,10 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
 from app.api import routes
+from app.api.vscode_routes import router as vscode_router
 from app.core.config import settings
 from app.core.utils import limiter
+from app.core.database import health_check
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -80,6 +82,7 @@ app.add_middleware(
 )
 
 app.include_router(routes.router, prefix="/api/v1")
+app.include_router(vscode_router, prefix="/api")
 
 
 # Add root route for status monitoring

--- a/extension-api/app/main.py
+++ b/extension-api/app/main.py
@@ -14,8 +14,8 @@ from slowapi.middleware import SlowAPIMiddleware
 from app.api import routes
 from app.api.vscode_routes import router as vscode_router
 from app.core.config import settings
-from app.core.utils import limiter
 from app.core.database import health_check
+from app.core.utils import limiter
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)

--- a/extension-api/app/main_simple.py
+++ b/extension-api/app/main_simple.py
@@ -100,7 +100,7 @@ async def export_vscode_extensions(
         raise HTTPException(status_code=400, detail="No extensions provided")
     if len(export_data.extensions) > 1000:  # Reasonable limit
         raise HTTPException(status_code=400, detail="Too many extensions (max: 1000)")
-    
+
     logger.info("🚀 VS CODE EXPORT - Endpoint called")
     logger.info(
         f"🚀 VS CODE EXPORT - Number of extensions: {len(export_data.extensions)}"

--- a/extension-api/app/main_simple.py
+++ b/extension-api/app/main_simple.py
@@ -33,6 +33,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 # Pydantic models
 class VSCodeExtension(BaseModel):
     id: str
@@ -41,19 +42,23 @@ class VSCodeExtension(BaseModel):
     name: str
     publisher: str
 
+
 class ExportCollectionRequest(BaseModel):
     extensions: List[Dict[str, str]]
     collectionName: Optional[str] = None
     description: Optional[str] = None
+
 
 class ExportCollectionResponse(BaseModel):
     collectionId: str
     collectionUrl: str
     message: str
 
+
 # In-memory storage for development
 collections_db = {}
 api_keys_db = {}
+
 
 # Health check endpoint
 @app.get("/health")
@@ -61,23 +66,25 @@ async def health_check():
     """Health check endpoint"""
     return {"status": "healthy", "message": "Cur8t Extension API is running"}
 
+
 # Test authentication endpoint
 @app.get("/api/test-auth")
 async def test_auth(authorization: Optional[str] = Header(None)):
     """Test authentication endpoint"""
     if not authorization:
         raise HTTPException(status_code=401, detail="Authorization header required")
-    
+
     if not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Invalid authorization format")
-    
+
     api_key = authorization[7:]  # Remove "Bearer " prefix
-    
+
     # For development, accept any API key that starts with "dev-"
     if api_key.startswith("dev-"):
         return {"status": "authenticated", "api_key": api_key[:8] + "..."}
-    
+
     raise HTTPException(status_code=401, detail="Invalid API key")
+
 
 # Export VS Code extensions endpoint
 @app.post("/api/export-collection", response_model=ExportCollectionResponse)
@@ -88,29 +95,37 @@ async def export_vscode_extensions(
 ) -> ExportCollectionResponse:
     """Export VS Code extensions to a Cur8t collection"""
     logger.info("🚀 VS CODE EXPORT - Endpoint called")
-    logger.info(f"🚀 VS CODE EXPORT - Number of extensions: {len(export_data.extensions)}")
+    logger.info(
+        f"🚀 VS CODE EXPORT - Number of extensions: {len(export_data.extensions)}"
+    )
 
     # Validate authorization
     if not authorization:
         raise HTTPException(status_code=401, detail="Authorization header required")
-    
+
     if not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Invalid authorization format")
-    
+
     api_key = authorization[7:]  # Remove "Bearer " prefix
-    
+
     # For development, accept any API key that starts with "dev-"
     if not api_key.startswith("dev-"):
         raise HTTPException(status_code=401, detail="Invalid API key")
 
     try:
         # Create collection name and description
-        collection_name = export_data.collectionName or f"VS Code Extensions - {datetime.now().strftime('%Y-%m-%d')}"
-        collection_description = export_data.description or f"Exported {len(export_data.extensions)} VS Code extensions on {datetime.now().strftime('%Y-%m-%d')}"
+        collection_name = (
+            export_data.collectionName
+            or f"VS Code Extensions - {datetime.now().strftime('%Y-%m-%d')}"
+        )
+        collection_description = (
+            export_data.description
+            or f"Exported {len(export_data.extensions)} VS Code extensions on {datetime.now().strftime('%Y-%m-%d')}"
+        )
 
         # Create new collection
         collection_id = str(uuid.uuid4())
-        
+
         # Store collection in memory
         collections_db[collection_id] = {
             "id": collection_id,
@@ -120,18 +135,20 @@ async def export_vscode_extensions(
             "user_id": "dev-user",
             "total_links": len(export_data.extensions),
             "created_at": datetime.now().isoformat(),
-            "extensions": export_data.extensions
+            "extensions": export_data.extensions,
         }
 
         # Create collection URL for the response
         collection_view_url = f"https://cur8t.com/collection/{collection_id}"
 
-        logger.info(f"🚀 VS CODE EXPORT - Successfully created collection with {len(export_data.extensions)} extension links")
+        logger.info(
+            f"🚀 VS CODE EXPORT - Successfully created collection with {len(export_data.extensions)} extension links"
+        )
 
         return ExportCollectionResponse(
             collectionId=collection_id,
             collectionUrl=collection_view_url,
-            message=f"Successfully exported {len(export_data.extensions)} VS Code extensions to Cur8t collection"
+            message=f"Successfully exported {len(export_data.extensions)} VS Code extensions to Cur8t collection",
         )
 
     except Exception as e:
@@ -139,6 +156,7 @@ async def export_vscode_extensions(
         raise HTTPException(
             status_code=500, detail=f"Failed to export VS Code extensions: {str(e)}"
         )
+
 
 # Get user collections endpoint
 @app.get("/api/user/collections")
@@ -151,12 +169,12 @@ async def get_user_collections(
     # Validate authorization
     if not authorization:
         raise HTTPException(status_code=401, detail="Authorization header required")
-    
+
     if not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Invalid authorization format")
-    
+
     api_key = authorization[7:]  # Remove "Bearer " prefix
-    
+
     # For development, accept any API key that starts with "dev-"
     if not api_key.startswith("dev-"):
         raise HTTPException(status_code=401, detail="Invalid API key")
@@ -182,6 +200,7 @@ async def get_user_collections(
             status_code=500, detail=f"Failed to fetch user collections: {str(e)}"
         )
 
+
 # Get specific collection endpoint
 @app.get("/api/collections/{collection_id}")
 async def get_collection_by_id(
@@ -193,12 +212,12 @@ async def get_collection_by_id(
     # Validate authorization
     if not authorization:
         raise HTTPException(status_code=401, detail="Authorization header required")
-    
+
     if not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Invalid authorization format")
-    
+
     api_key = authorization[7:]  # Remove "Bearer " prefix
-    
+
     # For development, accept any API key that starts with "dev-"
     if not api_key.startswith("dev-"):
         raise HTTPException(status_code=401, detail="Invalid API key")
@@ -227,6 +246,8 @@ async def get_collection_by_id(
             status_code=500, detail=f"Failed to fetch collection details: {str(e)}"
         )
 
+
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8001, reload=True)

--- a/extension-api/app/main_simple.py
+++ b/extension-api/app/main_simple.py
@@ -94,6 +94,13 @@ async def export_vscode_extensions(
     authorization: Optional[str] = Header(None),
 ) -> ExportCollectionResponse:
     """Export VS Code extensions to a Cur8t collection"""
+
+    # Validate input data
+    if not export_data.extensions:
+        raise HTTPException(status_code=400, detail="No extensions provided")
+    if len(export_data.extensions) > 1000:  # Reasonable limit
+        raise HTTPException(status_code=400, detail="Too many extensions (max: 1000)")
+    
     logger.info("🚀 VS CODE EXPORT - Endpoint called")
     logger.info(
         f"🚀 VS CODE EXPORT - Number of extensions: {len(export_data.extensions)}"

--- a/extension-api/app/main_simple.py
+++ b/extension-api/app/main_simple.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+Simplified FastAPI app for VS Code extension development
+This version removes database dependencies and focuses on basic functionality
+"""
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from fastapi import FastAPI, Header, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Create FastAPI app
+app = FastAPI(
+    title="Cur8t Extension API",
+    description="API for VS Code extension integration",
+    version="0.1.0",
+)
+
+# Add CORS middleware
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Allow all origins for development
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Pydantic models
+class VSCodeExtension(BaseModel):
+    id: str
+    version: str
+    description: str
+    name: str
+    publisher: str
+
+class ExportCollectionRequest(BaseModel):
+    extensions: List[Dict[str, str]]
+    collectionName: Optional[str] = None
+    description: Optional[str] = None
+
+class ExportCollectionResponse(BaseModel):
+    collectionId: str
+    collectionUrl: str
+    message: str
+
+# In-memory storage for development
+collections_db = {}
+api_keys_db = {}
+
+# Health check endpoint
+@app.get("/health")
+async def health_check():
+    """Health check endpoint"""
+    return {"status": "healthy", "message": "Cur8t Extension API is running"}
+
+# Test authentication endpoint
+@app.get("/api/test-auth")
+async def test_auth(authorization: Optional[str] = Header(None)):
+    """Test authentication endpoint"""
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Authorization header required")
+    
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid authorization format")
+    
+    api_key = authorization[7:]  # Remove "Bearer " prefix
+    
+    # For development, accept any API key that starts with "dev-"
+    if api_key.startswith("dev-"):
+        return {"status": "authenticated", "api_key": api_key[:8] + "..."}
+    
+    raise HTTPException(status_code=401, detail="Invalid API key")
+
+# Export VS Code extensions endpoint
+@app.post("/api/export-collection", response_model=ExportCollectionResponse)
+async def export_vscode_extensions(
+    request: Request,
+    export_data: ExportCollectionRequest,
+    authorization: Optional[str] = Header(None),
+) -> ExportCollectionResponse:
+    """Export VS Code extensions to a Cur8t collection"""
+    logger.info("🚀 VS CODE EXPORT - Endpoint called")
+    logger.info(f"🚀 VS CODE EXPORT - Number of extensions: {len(export_data.extensions)}")
+
+    # Validate authorization
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Authorization header required")
+    
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid authorization format")
+    
+    api_key = authorization[7:]  # Remove "Bearer " prefix
+    
+    # For development, accept any API key that starts with "dev-"
+    if not api_key.startswith("dev-"):
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+    try:
+        # Create collection name and description
+        collection_name = export_data.collectionName or f"VS Code Extensions - {datetime.now().strftime('%Y-%m-%d')}"
+        collection_description = export_data.description or f"Exported {len(export_data.extensions)} VS Code extensions on {datetime.now().strftime('%Y-%m-%d')}"
+
+        # Create new collection
+        collection_id = str(uuid.uuid4())
+        
+        # Store collection in memory
+        collections_db[collection_id] = {
+            "id": collection_id,
+            "title": collection_name,
+            "description": collection_description,
+            "visibility": "private",
+            "user_id": "dev-user",
+            "total_links": len(export_data.extensions),
+            "created_at": datetime.now().isoformat(),
+            "extensions": export_data.extensions
+        }
+
+        # Create collection URL for the response
+        collection_view_url = f"https://cur8t.com/collection/{collection_id}"
+
+        logger.info(f"🚀 VS CODE EXPORT - Successfully created collection with {len(export_data.extensions)} extension links")
+
+        return ExportCollectionResponse(
+            collectionId=collection_id,
+            collectionUrl=collection_view_url,
+            message=f"Successfully exported {len(export_data.extensions)} VS Code extensions to Cur8t collection"
+        )
+
+    except Exception as e:
+        logger.error(f"❌ Unexpected error in VS Code export: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to export VS Code extensions: {str(e)}"
+        )
+
+# Get user collections endpoint
+@app.get("/api/user/collections")
+async def get_user_collections(
+    request: Request, authorization: Optional[str] = Header(None)
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Get user's collections for VS Code extension"""
+    logger.info("📁 USER COLLECTIONS - Endpoint called")
+
+    # Validate authorization
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Authorization header required")
+    
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid authorization format")
+    
+    api_key = authorization[7:]  # Remove "Bearer " prefix
+    
+    # For development, accept any API key that starts with "dev-"
+    if not api_key.startswith("dev-"):
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+    try:
+        # Get all collections from memory
+        collections = []
+        for collection_id, collection_data in collections_db.items():
+            collection = {
+                "id": collection_id,
+                "name": collection_data["title"],
+                "description": collection_data["description"],
+                "createdAt": collection_data["created_at"],
+                "extensionCount": collection_data["total_links"],
+            }
+            collections.append(collection)
+
+        return {"collections": collections}
+
+    except Exception as e:
+        logger.error(f"❌ Unexpected error in user collections: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to fetch user collections: {str(e)}"
+        )
+
+# Get specific collection endpoint
+@app.get("/api/collections/{collection_id}")
+async def get_collection_by_id(
+    collection_id: str, authorization: Optional[str] = Header(None)
+) -> Dict[str, Any]:
+    """Get specific collection details"""
+    logger.info(f"📁 COLLECTION DETAILS - Endpoint called for ID: {collection_id}")
+
+    # Validate authorization
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Authorization header required")
+    
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid authorization format")
+    
+    api_key = authorization[7:]  # Remove "Bearer " prefix
+    
+    # For development, accept any API key that starts with "dev-"
+    if not api_key.startswith("dev-"):
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+    try:
+        # Get collection from memory
+        if collection_id not in collections_db:
+            raise HTTPException(status_code=404, detail="Collection not found")
+
+        collection_data = collections_db[collection_id]
+        collection = {
+            "id": collection_id,
+            "name": collection_data["title"],
+            "description": collection_data["description"],
+            "createdAt": collection_data["created_at"],
+            "extensionCount": collection_data["total_links"],
+        }
+
+        return collection
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"❌ Unexpected error in collection details: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to fetch collection details: {str(e)}"
+        )
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8001, reload=True)

--- a/extension-api/run_simple.py
+++ b/extension-api/run_simple.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""
+Simple runner for the VS Code extension API
+This version bypasses database dependencies for development
+"""
+
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run(
+        "app.main_simple:app",
+        host="0.0.0.0",
+        port=8001,
+        reload=True,
+        log_level="info",
+        workers=1,
+        loop="asyncio",
+        http="httptools",
+    )

--- a/extension-api/start_server.bat
+++ b/extension-api/start_server.bat
@@ -1,0 +1,4 @@
+@echo off
+echo Starting Cur8t Extension API Server...
+python run_simple.py
+pause


### PR DESCRIPTION
Created 4 new API routes for cur8t-vscode extension

`/api/validate` : Validate API key and return basic user info
`/api/export-collection` : Export VS Code extensions to a Cur8t collection
`/api/user-collections` : Get user's collections
`/api/collection` : Get specific collection details

before publishing the extension these routes must to be live

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New VS Code extension API: validate API keys, export extensions to public collections, list user collections, and fetch collection details.
  * Health check endpoint for monitoring.

* **Chores**
  * Added a simplified development server with in-memory auth and test auth route.
  * Added scripts to run the development server on Windows and via Python.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->