### PR TITLE
Feat: Added Extension Button to Navbar

### DIFF
--- a/cur8t-web/src/app/page.tsx
+++ b/cur8t-web/src/app/page.tsx
@@ -111,6 +111,11 @@ const Home = () => {
           />
           <div className="flex items-center space-x-2">
             {isSignedIn ? (
+              <Link href="https://chromewebstore.google.com/detail/nmimopllfhdfejjajepepllgdpkglnnj?utm_source=item-share-cb">
+                <NavbarButton variant="primary" as="button">
+                  Get Extention
+                </NavbarButton>
+              </Link>
               <Link href="/dashboard?item=Overview">
                 <NavbarButton variant="primary" as="button">
                   Dashboard


### PR DESCRIPTION
Added Extension Button to Navbar

Currently, users need to navigate to Dashboard → Integrations to find the extension download option. This PR adds a dedicated "Extension" button to the navbar (visible when logged in) to improve discoverability and make it easier for users to find and install the browser extension.

<img width="1823" height="915" alt="image" src="https://github.com/user-attachments/assets/f5bf37d4-4789-4c7b-9189-ccad5ef3a4cb" />